### PR TITLE
Fix of few setup issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ micromamba activate jafar
 micromamba install pytorch==2.4.1 torchvision==0.19.1 pytorch-cuda=11.8 -c pytorch -c nvidia -c conda-forge -y
 
 pip install uv
-uv pip install einops==0.8.0 matplotlib==3.7.0 numpy==1.24.4 timm==1.0.11 plotly tensorboard hydra-core ipykernel rich pytest scikit-learn torchmetrics==1.6.2
+uv pip install einops==0.8.0 matplotlib==3.7.0 numpy==1.24.4 timm==1.0.11 plotly tensorboard hydra-core ipykernel rich pytest scikit-learn torchmetrics==1.6.2 transformers
 ```
 </details>
 

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -31,8 +31,8 @@ unzip downloads/stuffthingmaps_trainval2017.zip -d dataset/annotations/
 # https://github.com/xu-ji/IIC/blob/master/datasets/README.txt
 wget https://www.robots.ox.ac.uk/~xuji/datasets/COCOStuff164kCurated.tar.gz
 tar -xzf COCOStuff164kCurated.tar.gz
-mv COCO/COCOStuff164k ./currated
-rmdir COCO
+mv COCO/COCOStuff164k/curated ./curated
+rm -r COCO
 rm COCOStuff164kCurated.tar.gz
 cd ../
 ```


### PR DESCRIPTION
Hi,
`transformers` is required for the linear probe depth evaluation training and there was a typo in the dataset setup script.
Should be fixed now.
Best, Thomas